### PR TITLE
Convert width setting value to number

### DIFF
--- a/Thumbnail/index.js
+++ b/Thumbnail/index.js
@@ -6,7 +6,7 @@ const blobService = storage.createBlobService();
 
 module.exports = (context, myEvent, myBlob) => {
 
-  const widthInPixels = process.env.THUMBNAIL_WIDTH;
+  const widthInPixels = Number(process.env.THUMBNAIL_WIDTH);
   const blobName = myEvent.subject.split('/')[6];
 
     Jimp.read(myBlob).then((thumbnail) => {


### PR DESCRIPTION
Convert the type of the variable containing the application's
THUMBNAIL_WIDTH setting value from a string to a number since
Jimp.resize takes numbers as its parameters. This fixes a bug that
crashes the function.

## Purpose
Fix a bug that crashes the function.

## Does this introduce a breaking change?
<!-- Mark one with an "x". -->
```
[ ] Yes
[X] No
```

## Pull Request Type
What kind of change does this Pull Request introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[X] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Documentation content changes
[ ] Other... Please describe:
```