### PR TITLE
Update sample to use latest libs

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,6 +14,9 @@ This sample implements a function triggered by Azure Blob Storage to resize an i
 
 The key aspects of this sample are in the function bindings and implementation.
 
+## Use latest Storage Blob SDK
+The Storage Blob SDK package version in this repo is 2.x. It's strongly recommended that you use the latest version of the Storage Blob SDK package, please refer to the sample [storage-blob-resize-function](https://github.com/Azure/azure-sdk-for-js/tree/master/sdk/storage/storage-blob/samples/storage-blob-resize-function).
+
 ## Function bindings
 In order to interface with image data, you need to configure the function to process binary data.
 

--- a/README.md
+++ b/README.md
@@ -46,32 +46,37 @@ The sample uses [Jimp](https://github.com/oliver-moran/jimp) to resize an incomi
 
 
 ```javascript
-const stream = require('stream');
 const Jimp = require('jimp');
+const stream = require('stream');
+const { BlockBlobClient } = require("@azure/storage-blob");
 
-const storage = require('azure-storage');
-const blobService = storage.createBlobService();
+const ONE_MEGABYTE = 1024 * 1024;
+const uploadOptions = { bufferSize: 4 * ONE_MEGABYTE, maxBuffers: 20 };
 
-module.exports = (context, myEvent, myBlob) => {
+const containerName = process.env.BLOB_CONTAINER_NAME;
+const connectionString = process.env.AZURE_STORAGE_CONNECTION_STRING;
+const blobName = process.env.OUT_BLOB_NAME;
 
-  const widthInPixels = process.env.THUMBNAIL_WIDTH;
-  const blobName = myEvent.subject.split('/')[6];
-
-    Jimp.read(myBlob).then((thumbnail) => {
-
+module.exports = async function (context, myEvent, inputBlob){
+    const widthInPixels = 100;
+    Jimp.read(inputBlob).then((thumbnail) => {
         thumbnail.resize(widthInPixels, Jimp.AUTO);
-
-        thumbnail.getBuffer(Jimp.MIME_PNG, (err, buffer) => {
-
+        thumbnail.getBuffer(Jimp.MIME_PNG, async (err, buffer) => {
+          
             const readStream = stream.PassThrough();
             readStream.end(buffer);
-
-            blobService.createBlockBlobFromStream('thumbnails', blobName, readStream, buffer.length, (err) => {
-                context.done();
-            });
+            const blobClient = new BlockBlobClient(connectionString, containerName, blobName);
+            
+            try {
+                await blobClient.uploadStream(readStream,
+                    uploadOptions.bufferSize,
+                    uploadOptions.maxBuffers,
+                    { blobHTTPHeaders: { blobContentType: "image/jpeg" } });
+            } catch (err) {
+                context.log(err.message);
+            }
         });
-
-    }).catch(context.log);
+    });
 };
 ```
 

--- a/README.md
+++ b/README.md
@@ -10,12 +10,11 @@ urlFragment: storage-blob-resize-function-node
 
 # Azure Storage Blob Trigger Image Resize Function in Node.js
 
+> IMPORTANT! This sample uses the older version of the Storage Blob SDK i.e. azure-storage. Please refer to the sample [storage-blob-resize-function](https://github.com/Azure/azure-sdk-for-js/tree/master/sdk/storage/storage-blob/samples/storage-blob-resize-function) that uses the latest version of the Storage Blob SDK i.e. [@azure/storage-blob](https://www.npmjs.com/package/@azure/storage-blob) instead.
+
 This sample implements a function triggered by Azure Blob Storage to resize an image in Node.js. Once the image is resized, the thumbnail image is uploaded back to blob storage.
 
 The key aspects of this sample are in the function bindings and implementation.
-
-## Use latest Storage Blob SDK
-The Storage Blob SDK package version in this repo is 2.x. It's strongly recommended that you use the latest version of the Storage Blob SDK package, please refer to the sample [storage-blob-resize-function](https://github.com/Azure/azure-sdk-for-js/tree/master/sdk/storage/storage-blob/samples/storage-blob-resize-function).
 
 ## Function bindings
 In order to interface with image data, you need to configure the function to process binary data.

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "description": "",
   "main": "index.js",
   "dependencies": {
-    "azure-storage": "^2.8.1",
+    "@azure/storage-blob": "^12.5.0",
     "jimp": "^0.2.28"
   },
   "devDependencies": {},

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "description": "",
   "main": "index.js",
   "dependencies": {
-    "@azure/storage-blob": "^12.5.0",
+    "@azure/storage-blob": "^12.6.0",
     "jimp": "^0.2.28"
   },
   "devDependencies": {},


### PR DESCRIPTION
According to the https://github.com/Azure-Samples/storage-blob-resize-function-node-v10/pull/1#issuecomment-788220155,  update README to archive this repo with pointer to the [new sample](https://github.com/azure/azure-sdk-for-js/tree/master/sdk/storage/storage-blob/samples).

@ramya-rao-a @jongio for notification.